### PR TITLE
refact: refactor the “prepareStringable”/”prepareRepeatable” approach

### DIFF
--- a/packages/core/src/ItemWithParams/ItemWithParams.ts
+++ b/packages/core/src/ItemWithParams/ItemWithParams.ts
@@ -1,8 +1,6 @@
 import { ItemValue } from '../types/ItemValue';
 import { Param, ParamValue } from '../Param';
-import { evalMath } from '../utils/evalMath';
-import { prepareStringable } from './prepareStringable';
-import { prepareRepeatable } from './prepareRepeatable';
+import { ParamEvaluator } from './ParamsValueEvaluator';
 
 export const isItemWithParams = (item: ItemWithParams | unknown): item is ItemWithParams => {
   // This does not always catch all cases
@@ -11,6 +9,7 @@ export const isItemWithParams = (item: ItemWithParams | unknown): item is ItemWi
   if(
     item !== null
     && typeof item === 'object'
+    // @ts-ignore
     && 'type' in item && item.type === 'ItemWithParams'
     && 'value' in item
     && 'params' in item
@@ -31,13 +30,13 @@ export class ItemWithParams {
         const param = rawParams.find(p => p.name === key);
         if (!param) throw new Error(`Param "${key}" does not exist`);
 
-        if(param.type === 'StringableParam') return prepareStringable(value, param);
-
-        // TODO
-        // if(param.type === 'RepeatableParam') return prepareRepeatable(value, param);
-
-        // Default to the raw value
-        return param.value;
+        try {
+          const paramEvaluatorInstance = new ParamEvaluator();
+          return paramEvaluatorInstance.evaluate(value, param);
+        } catch (error) {
+          console.error('error', error);
+          return param.value;
+        }
       }
     });
   }

--- a/packages/core/src/ItemWithParams/ParamsValueEvaluator.ts
+++ b/packages/core/src/ItemWithParams/ParamsValueEvaluator.ts
@@ -1,0 +1,22 @@
+import { Param } from '../Param';
+import { ItemValue } from '../types/ItemValue';
+import { StringableParamEvaluator } from './prepareStringable';
+import { ParamsValueEvaluator } from '../types/ItemWithParams';
+import { RepeatableParamEvaluator } from './prepareRepeatable';
+
+class ParamEvaluator implements ParamsValueEvaluator<any>{
+  private evaluators: ParamsValueEvaluator<Param>[] = [
+    new StringableParamEvaluator(),
+    new RepeatableParamEvaluator(this),
+  ]
+
+  canEvaluate(param: Param): param is Param {
+    return this.evaluators.some(e => e.canEvaluate(param));
+  }
+  evaluate(itemValue: ItemValue, param: Param) {
+    const evaluator = this.evaluators.find(e => e.canEvaluate(param));
+    if(!evaluator) throw new Error(`No evaluator for param type "${param.type}"`);
+
+    return evaluator.evaluate(itemValue, param);
+  }
+}

--- a/packages/core/src/ItemWithParams/ParamsValueEvaluator.ts
+++ b/packages/core/src/ItemWithParams/ParamsValueEvaluator.ts
@@ -4,7 +4,7 @@ import { StringableParamEvaluator } from './prepareStringable';
 import { ParamsValueEvaluator } from '../types/ItemWithParams';
 import { RepeatableParamEvaluator } from './prepareRepeatable';
 
-class ParamEvaluator implements ParamsValueEvaluator<any>{
+export class ParamEvaluator implements ParamsValueEvaluator<any>{
   private evaluators: ParamsValueEvaluator<Param>[] = [
     new StringableParamEvaluator(),
     new RepeatableParamEvaluator(this),

--- a/packages/core/src/ItemWithParams/prepareRepeatable.ts
+++ b/packages/core/src/ItemWithParams/prepareRepeatable.ts
@@ -1,9 +1,17 @@
 import { Param, RepeatableParam, StringableParam } from '../Param';
 import { ItemValue } from '../types/ItemValue';
-import { evalMath } from '../utils/evalMath';
-import { get } from '../utils/get';
-import Hjson from '@data-story/hjson';
-import { prepareStringable } from './prepareStringable';
+import { ParamsValueEvaluator } from '../types/ItemWithParams';
+
+export class RepeatableParamEvaluator implements ParamsValueEvaluator<RepeatableParam<any>> {
+  constructor(private evaluator: ParamsValueEvaluator<any>) {
+  }
+  evaluate(itemValue: ItemValue, param: RepeatableParam<any>) {
+    return Object.fromEntries(param.row.map((row: {name: string}) =>
+      [row.name, this.evaluator.evaluate(itemValue, row)] as const));
+  }
+  type = 'RepeatableParam' as const;
+  canEvaluate = (param: Param): param is RepeatableParam<any> => param.type === this.type;
+}
 
 export const prepareRepeatable = (itemValue: ItemValue, param: Param) => {
   // TODO

--- a/packages/core/src/ItemWithParams/prepareStringable.ts
+++ b/packages/core/src/ItemWithParams/prepareStringable.ts
@@ -3,7 +3,15 @@ import { ItemValue } from '../types/ItemValue';
 import { evalMath } from '../utils/evalMath';
 import { get } from '../utils/get';
 import Hjson from '@data-story/hjson';
+import { ParamsValueEvaluator } from '../types/ItemWithParams';
 
+export class StringableParamEvaluator implements ParamsValueEvaluator<StringableParam> {
+  evaluate(itemValue: ItemValue, param: StringableParam) {
+    return prepareStringable(itemValue, param);
+  }
+  type = 'StringableParam' as const;
+  canEvaluate = (param: Param): param is StringableParam => param.type === this.type;
+}
 export const prepareStringable = (itemValue: ItemValue, param: Param) => {
   // **********************************************************************
   // VALIDATE

--- a/packages/core/src/types/ItemWithParams.ts
+++ b/packages/core/src/types/ItemWithParams.ts
@@ -1,0 +1,7 @@
+import { Param } from '../Param';
+import { ItemValue } from './ItemValue';
+
+export interface ParamsValueEvaluator<TParams extends Param> {
+  canEvaluate: (param: Param) => param is TParams;
+  evaluate(itemValue: ItemValue, param: TParams): any;
+}

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/nodeSettingsModal.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/nodeSettingsModal.tsx
@@ -68,7 +68,7 @@ export const NodeSettingsModalContent = () => {
             // Param fields
             for (const [key, value] of Object.entries(submitted.params)) {
               const param = newData.params.find((p) => p.name === key)!;
-              param?.value && (param.value = value);
+              if(param.hasOwnProperty('value')) param.value = value;
             }
 
             n.data = newData;


### PR DESCRIPTION
refact: refactor the “prepareStringable”/”prepareRepeatable” approach

![image](https://github.com/stone-lyl/data-story/assets/20497176/37ab9f82-a5c6-4294-b5f2-2c8fd7d39d48)

fix: fixed the issue where param.value could not be assigned when the param.value is empty

Before

https://github.com/stone-lyl/data-story/assets/20497176/1d88ff57-356e-4935-9d8d-c55e93e113e8 

After 

https://github.com/stone-lyl/data-story/assets/20497176/a09964a5-fbf6-4a28-8bc6-d31ff5adc2af 

